### PR TITLE
Regression discontinuity vignette and designer documentation

### DIFF
--- a/R/regression_discontinuity_designer.R
+++ b/R/regression_discontinuity_designer.R
@@ -1,5 +1,7 @@
 #' Create a regression discontinuity design
 #'
+#' A regression discontinuity design with sample from population of size \code{N}. The average treatment effect local to the cutpoint is equal to \code{tau}. It allows for specification of the order of the polynomial regression (\code{poly_order}), cuttoff value on the running variable (\code{cutoff}), and size of bandwidth around the cutoff (\code{bandwidth}).
+#'
 #' @param N An integer. Size of population to sample from.
 #' @param tau A scalar number. Difference in potential outcomes functions at the threshold.
 #' @param cutoff A scalar number in (0,1). Threshold on running variable beyond which units are treated.

--- a/man/regression_discontinuity_designer.Rd
+++ b/man/regression_discontinuity_designer.Rd
@@ -22,7 +22,7 @@ regression_discontinuity_designer(N = 1000, tau = 0.15, cutoff = 0.5,
 A regression discontinuity design design
 }
 \description{
-Create a regression discontinuity design
+A regression discontinuity design with sample from population of size \code{N}. The average treatment effect local to the cutpoint is equal to \code{tau}. It allows for specification of the order of the polynomial regression (\code{poly_order}), cuttoff value on the running variable (\code{cutoff}), and size of bandwidth around the cutoff (\code{bandwidth}).
 }
 \examples{
 # A regression discontinuity design using default arguments:

--- a/vignettes/regression_discontinuity.Rmd
+++ b/vignettes/regression_discontinuity.Rmd
@@ -112,6 +112,30 @@ Second, the design is biased because polynomial approximations of the average ef
 
 Finally, from the figure, we can see how poorly the average effect at the threshold approximates the average effect for all units. The average treatment effect among the treated (to the right of the threshold in the figure) is negative, whereas at the threshold it is positive. This clarifies that the estimand of the regression discontinuity design, the difference at the cutoff, is only relevant for a small – and possibly empty – set of units very close to the cutoff.
 
+### Using the Regression Discontinuity Designer
+
+In R, you can generate a regression_discontinuity design using the template function `regression_discontinuity_designer()` in the `DesignLibrary` package by running the following lines, which install and load the package:
+
+```{r, eval=FALSE}
+install.packages("DesignLibrary")
+library(DesignLibrary)
+```
+
+We can then create specific designs by defining values for each argument. For example, we create a design called `my_regression_discontinuity_design` with `N`, `ate`, `rho`, and `attrition_rate` set to 300, .2, .4, and .15, respectively, by running the lines below.
+
+```{r, eval=FALSE}
+regression_discontinuity_design <- regression_discontinuity_designer(N = 300,
+                                                        ate = .2,
+                                                        rho = .4,
+                                                        attrition_rate = .15)
+```
+
+You can see more details on the `regression_discontinuity_designer()` function and its arguments by running the following line of code:
+
+```{r, eval=FALSE}
+??regression_discontinuity_designer
+```
+
 ## Further reading
 
 1. Since its rediscovery by social scientists in the late 1990s, the regression discontinuity design has been widely used to study diverse causal effects such as: prison on recidivism (Mitchell et al., 2017); China’s one child policy on human capital (Qin, Zhuang and Yang, 2017); eligibility for World Bank loans on political liberalization (Carnegie and Samii, 2017); and anti-discrimination laws on minority employment (Hahn, Todd and Van der Klaauw, 1999).

--- a/vignettes/regression_discontinuity.Rmd
+++ b/vignettes/regression_discontinuity.Rmd
@@ -90,7 +90,7 @@ ggplot(plot_frame,aes(x = X, y = Y, color = as.factor(Z))) +
 
 - **A**nswer strategy: We will approximate the treated and untreated conditional expectation functions to the left and right of the cutoff using a flexible regression specification estimated via OLS. In particular, we fit each regression using a fourth-order polynomial. Much of the literature on regression discontinuity designs focuses on the tradeoffs among answer strategies, with many analysts recommending against higher-order polynomial regression specifications. We use one here to highlight how well such an answer strategy does when it matches the functional form in the model. We discuss alternative estimators in the exercises. 
 
-```{r,eval = FALSE, code = get_design_code(regression_discontinuity_design)}
+```{r, eval = TRUE, code = get_design_code(regression_discontinuity_designer())}
 
 ```
 

--- a/vignettes/regression_discontinuity.Rmd
+++ b/vignettes/regression_discontinuity.Rmd
@@ -14,6 +14,7 @@ vignette: >
 ```{r MIDA, echo = FALSE,include = FALSE}
 library(DesignLibrary)
 library(ggplot2)
+library(knitr)
 ```
 
 ## Regression Discontinuity
@@ -35,7 +36,7 @@ We'll consider an application of the regression discontinuity design that examin
     A major assumption required for regression discontinuity is that the conditional expectation functions for both treatment and control potential outcomes are continuous at the cutoff.^[An alternative motivation for some designs that do not rely on continuity at the cutoff is "local randomization".] To satisfy this assumption, we specify two smooth conditional expectation functions, one for each potential outcome. The figure plots $Y$ (the Democratic vote margin at time $t$) against $X$ (the margin at time $t-1$). We've also plotted the true conditional expectation functions for the treated and control potential outcomes. The solid lines correspond to the observed data and the dashed lines correspond to the unobserved data.
     
     
-```{r,include=FALSE}
+```{r,include=FALSE, warning=FALSE, message=FALSE}
 pro_con_colors <- c("#C67800", "#205C8A")
 dd_theme <-
   function() {
@@ -71,7 +72,7 @@ control_frame <- data.frame(
 plot_frame <- rbind(treatment_frame, control_frame)
 ```
 
-    ```{r,echo=FALSE}
+    ```{r,echo=FALSE,warning=FALSE, message=FALSE}
 ggplot(plot_frame,aes(x = X, y = Y, color = as.factor(Z))) + 
   geom_line(aes(linetype = observed)) +
   geom_point(data = mock_data, alpha = .2, size = .5) +
@@ -102,8 +103,8 @@ We now diagnose the design:
 diagnosis <- diagnose_design(regression_discontinuity_design)
 ```
 
-```{r}
-kable(reshape_diagnosis(diagnosis), digits = 2)
+```{r, echo=FALSE}
+kable(reshape_diagnosis(diagnosis)[,-c(1:2)], digits = 2)
 ```
 
 We highlight three takeaways. First, the power of this design is very low: with 1,000 units we do not achieve even 10% statistical power. However, our estimates of the uncertainty are not too wide: the coverage probability indicates that our confidence intervals indeed contain the estimand 95% of the time as they should. Our answer strategy is highly uncertain because the fourth-order polynomial specification in regression model gives weights to the data that greatly increase the variance of the estimator (Gelman and Imbens, 2017). In the exercises we explore alternative answer strategies that perform better.
@@ -121,13 +122,14 @@ install.packages("DesignLibrary")
 library(DesignLibrary)
 ```
 
-We can then create specific designs by defining values for each argument. For example, we create a design called `my_regression_discontinuity_design` with `N`, `ate`, `rho`, and `attrition_rate` set to 300, .2, .4, and .15, respectively, by running the lines below.
+We can then create specific designs by defining values for each argument. For example, we create a design called `my_regression_discontinuity_design` with our chosen values for `N`, `tau`, `cutoff`, `bandwidth`, and `poly_order` by running the lines below.
 
 ```{r, eval=FALSE}
 regression_discontinuity_design <- regression_discontinuity_designer(N = 300,
-                                                        ate = .2,
-                                                        rho = .4,
-                                                        attrition_rate = .15)
+                                                        tau = .2,
+                                                        cutoff = .4,
+                                                        bandwidth = .01,
+                                                        poly_order = .15)
 ```
 
 You can see more details on the `regression_discontinuity_designer()` function and its arguments by running the following line of code:

--- a/vignettes/regression_discontinuity.Rmd
+++ b/vignettes/regression_discontinuity.Rmd
@@ -94,6 +94,28 @@ ggplot(plot_frame,aes(x = X, y = Y, color = as.factor(Z))) +
 
 ```
 
+### Takeaways
 
+We now diagnose the design:
 
+```{r}
+diagnosis <- diagnose_design(regression_discontinuity_design)
+```
 
+```{r}
+kable(reshape_diagnosis(diagnosis), digits = 2)
+```
+
+We highlight three takeaways. First, the power of this design is very low: with 1,000 units we do not achieve even 10% statistical power. However, our estimates of the uncertainty are not too wide: the coverage probability indicates that our confidence intervals indeed contain the estimand 95% of the time as they should. Our answer strategy is highly uncertain because the fourth-order polynomial specification in regression model gives weights to the data that greatly increase the variance of the estimator (Gelman and Imbens, 2017). In the exercises we explore alternative answer strategies that perform better.
+
+Second, the design is biased because polynomial approximations of the average effect at exactly the point of the threshold will be inaccurate in small samples (Sekhon and Titiunik, 2017), especially as units farther away from the cutoff are incorporated into the answer strategy. We know that the estimated bias is not due to simulation error by examining the bootstrapped standard error of the bias estimates.
+
+Finally, from the figure, we can see how poorly the average effect at the threshold approximates the average effect for all units. The average treatment effect among the treated (to the right of the threshold in the figure) is negative, whereas at the threshold it is positive. This clarifies that the estimand of the regression discontinuity design, the difference at the cutoff, is only relevant for a small – and possibly empty – set of units very close to the cutoff.
+
+## Further reading
+
+1. Since its rediscovery by social scientists in the late 1990s, the regression discontinuity design has been widely used to study diverse causal effects such as: prison on recidivism (Mitchell et al., 2017); China’s one child policy on human capital (Qin, Zhuang and Yang, 2017); eligibility for World Bank loans on political liberalization (Carnegie and Samii, 2017); and anti-discrimination laws on minority employment (Hahn, Todd and Van der Klaauw, 1999).
+
+2. We’ve discussed a “sharp” regression discontinuity design in which all units above the threshold were treated and all units below were untreated. In fuzzy regression discontinuity designs, some units above the cutoff remain untreated or some units below take treatment. This setting is analogous to experiments that experience noncompliance and may require instrumental variables approaches to the answer strategy (see Compliance is a Potential Outcome).
+
+3. Geographic regression discontinuity designs use distance to a border as the running variable: units on one side of the border are treated and units on the other are untreated. Keele and Titiunik (2016) use such a design to study whether voters are more likely to turn out when they have the opportunity to vote directly on legislation on so-called ballot initiatives. A complication of this design is how to measure distance to the border in two dimensions.


### PR DESCRIPTION
Edits designer documentation
Added sections that were missing from the content already in archive as well as the "how to use this design" section.
Includes corrections to vignette Rmd chunck set up.