### PR TITLE
Tests for overview table up

### DIFF
--- a/tests/testthat/test_overview_table.R
+++ b/tests/testthat/test_overview_table.R
@@ -1,0 +1,45 @@
+context(desc = "Testing that overview table is correctly formatted")
+
+# Design overview table
+overview <- read.csv("../../data/overview.csv")
+
+# Get designers
+functions <- ls("package:DesignLibrary")
+designers <- functions[grepl("_designer\\b",functions)]
+
+# Get design vignettes
+vignettes <- list.files("vignettes")
+exclude_vignettes <- vignettes[which(grepl("how_to_write|bib.bib",vignettes,TRUE))]
+vignettes <- vignettes[-which(vignettes %in% exclude_vignettes)]
+vignettes <- gsub(".Rmd","",vignettes)
+
+testthat::test_that(
+  desc = paste0("No designers in the table should be absent from the library"),
+  code = {
+    expect_true(all(overview$designer %in% designers))
+  }
+)
+
+testthat::test_that(
+  desc = paste0("All designers in the library should be documented in the table"),
+  code = {
+    expect_true(all(designers %in% overview$designer))
+  }
+)
+
+testthat::test_that(
+  desc = paste0("No vignettes in the table should be absent from the library"),
+  code = {
+    expect_true(all(vignettes %in% overview$vignette))
+  }
+)
+
+testthat::test_that(
+  desc = paste0("All vignettes in the library should be documented in the table"),
+  code = {
+    expect_true(all(vignettes %in% overview$vignette))
+  }
+)
+
+
+


### PR DESCRIPTION
This is a bunch of checks that make sure when we add and remove designers/vignettes we update the overview table accordingly. 