### PR TITLE
New tests

### DIFF
--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -3,6 +3,7 @@ context(desc = "Testing that designers in the library work as they should")
 functions <- ls("package:DesignLibrary")
 designers <- functions[grepl("_designer\\b",functions)]
 
+# designers <- designers[-which(designers == "multi_arm_designer")]
 
 for(designer in designers){
   
@@ -98,8 +99,27 @@ test_that(desc = "simple_two_arm_designer errors when it should",
             expect_error(simple_two_arm_designer(rho = 10))
                                })
 
+test_that(desc = "mediation_analysis_designer errors when it should",
+          code = {
+            expect_error(mediation_analysis_designer(rho = 10))
+          })
 
+test_that(desc = "block_cluster_two_arm_designer errors when it should",
+          code = {
+            expect_error(block_cluster_two_arm_designer(rho = 10))
+          })
 
+test_that(desc = "pretest_posttest_designer errors when it should",
+          code = {
+            expect_error(pretest_posttest_designer(rho = 10))
+            expect_error(pretest_posttest_designer(attrition_rate = 10))
+          })
+
+test_that(desc = "cluster_sampling_designer errors when it should",
+          code = {
+            expect_error(cluster_sampling_designer(n_clusters = 10,N_clusters = 1))
+            expect_error(cluster_sampling_designer(n_subjects_per_cluster = 30,N_subjects_per_cluster = 10))
+          })
 
 
 

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -22,6 +22,12 @@ testthat::test_that(
 test_that(
   desc = "internal helpers for when source code is missing work",
   code = {
+    test_function <- function(){
+      {{{
+        mean(rnorm(100))
+      }}}
+    }
+    expect_is(DesignLibrary:::find_triple_bracket(f = test_function),"character")
     expect_equal(DesignLibrary:::find_triple_bracket(f = mean),"")
     expect_false(DesignLibrary:::pred(expr = mean(1:2),depth = 1))
     expect_true(DesignLibrary:::pred(expr = quote({{{mean(1:2)}}}),depth = 1))
@@ -31,6 +37,10 @@ test_that(desc = "construct_design_code works as it should when source is missin
           code = {
             expect_equal(DesignLibrary:::construct_design_code(designer = mean, args = c("x"),arguments_as_values = F,exclude_args = NULL),c("",""))
             expect_is(DesignLibrary:::construct_design_code(designer = function(x) {{{x}}}, args = c("x"),arguments_as_values = F,exclude_args = NULL),"character")
+            test_designer <- function() "{{{"
+            expect_error(DesignLibrary:::construct_design_code(designer = test_designer,args = "x"))
+            test_designer <- function() "}}}"
+            expect_error(DesignLibrary:::construct_design_code(designer = test_designer,args = "x"))
           }) 
 
 
@@ -48,5 +58,9 @@ test_that(desc = "return_args works fine",
           })
 
 
+test_that(desc = "clean_code works OK", 
+          code = {
+            expect_error(DesignLibrary:::clean_code("{#"),NA)
+          })
 
 


### PR DESCRIPTION
This gets coverage up to 100% on everything that is *not* multi_arm_designer.

The substitute method is still causing `multi_arm_designer` to break the tests in `covr::package_coverage()`, although oddly it is not a problem in `devtools::check()` or `devtools::test()`