### PR TITLE
Updated vignettes and library table

### DIFF
--- a/inst/extdata/overview.csv
+++ b/inst/extdata/overview.csv
@@ -7,8 +7,8 @@ multi_arm_design,multi_arm_designer,multi_arm,,multi_arm,DeclareDesign,https://d
 pretest_posttest_design,pretest_posttest_designer,pretest_posttest,,pretest_posttest,DeclareDesign,https://declaredesign.org/about/
 randomized_response_design,randomized_response_designer,randomized_response,,randomized_response,DeclareDesign,https://declaredesign.org/about/
 regression_discontinuity_design,regression_discontinuity_designer,regression_discontinuity,,regression_discontinuity,DeclareDesign,https://declaredesign.org/about/
-spillover_design,spillover_designer,spillover,,spillover,DeclareDesign,https://declaredesign.org/about/
-two_arm_design,two_arm_designer,two_arm,,two_arm,DeclareDesign,https://declaredesign.org/about/
+spillover_design,spillover_designer,simple_spillover,,spillover,DeclareDesign,https://declaredesign.org/about/
+two_arm_design,two_arm_designer,simple_two_arm,,two_arm,DeclareDesign,https://declaredesign.org/about/
 two_by_two_design,two_by_two_designer,,,two_by_two,DeclareDesign,https://declaredesign.org/about/
 two_arm_attrition_design,two_arm_attrition_designer,,,,DeclareDesign,https://declaredesign.org/about/
 process_tracing_design,process_tracing_designer,,,process_tracing,DeclareDesign,https://declaredesign.org/about/

--- a/vignettes/How_to_Write_and_Contribute_Designers.Rmd
+++ b/vignettes/How_to_Write_and_Contribute_Designers.Rmd
@@ -83,7 +83,7 @@ We've devised an easy way to include code in design objects returned by a design
 
 ## Our method for adding code
 
-One easy way to add code to the designs that your designer returns is to use our triple braces method. Any checks (such as those that look to see whether `prob` is between 0 and 1) come before the opening triple braces, `{{{`. Then, all the code needed to build the design goes between the triple braces:
+One easy way to add code to the designs that your designer returns is to use our triple braces method. Any checks (such as those that look to see whether `prob` is between 0 and 1) come before the opening triple braces, ` {{{ `. Then, all the code needed to build the design goes between the triple braces:
 
 ```{r, eval=FALSE}
 {{{ 
@@ -102,7 +102,7 @@ One easy way to add code to the designs that your designer returns is to use our
 }}}
 ```
 
-Our function `construct_design_code` goes into the designer and extracts all of the code between `{{{` and `}}}`. Then, `match.call.defaults()` checks what arguments the user gave the function, and adds them to the top of the extracted code in a list that looks like this:
+Our function `construct_design_code` goes into the designer and extracts all of the code between ` {{{ ` and ` }}} `. Then, `match.call.defaults()` checks what arguments the user gave the function, and adds them to the top of the extracted code in a list that looks like this:
 
 ```{r,eval = F}
 N <- 100                                                       

--- a/vignettes/How_to_Write_and_Contribute_Designers.Rmd
+++ b/vignettes/How_to_Write_and_Contribute_Designers.Rmd
@@ -83,7 +83,7 @@ We've devised an easy way to include code in design objects returned by a design
 
 ## Our method for adding code
 
-One easy way to add code to the designs that your designer returns is to use our triple braces method. Any checks (such as those that look to see whether `prob` is between 0 and 1) come before the opening triple braces, ` {{{ `. Then, all the code needed to build the design goes between the triple braces:
+One easy way to add code to the designs that your designer returns is to use our triple braces method. Any checks (such as those that look to see whether `prob` is between 0 and 1) come before the opening triple braces, <code> {{{ </code>. Then, all the code needed to build the design goes between the triple braces:
 
 ```{r, eval=FALSE}
 {{{ 
@@ -102,7 +102,7 @@ One easy way to add code to the designs that your designer returns is to use our
 }}}
 ```
 
-Our function `construct_design_code` goes into the designer and extracts all of the code between ` {{{ ` and ` }}} `. Then, `match.call.defaults()` checks what arguments the user gave the function, and adds them to the top of the extracted code in a list that looks like this:
+Our function `construct_design_code` goes into the designer and extracts all of the code between <code> {{{ </code> and <code> }}} </code>. Then, `match.call.defaults()` checks what arguments the user gave the function, and adds them to the top of the extracted code in a list that looks like this:
 
 ```{r,eval = F}
 N <- 100                                                       


### PR DESCRIPTION
# Description
- Updated the names of vignettes in the Library Overview table.
- Found a workaround so that the markdown `{{{` wouldn’t be interpreted as special characters by the site generator.

