### PR TITLE
Avoid conflict when diagnosing `expand_design()` object

### DIFF
--- a/R/multi_arm_designer.R
+++ b/R/multi_arm_designer.R
@@ -131,6 +131,7 @@ multi_arm_designer <- function(N = 30,
   estimator_expr <- expr(declare_estimator(
     handler = function(data){
       estimates <- rbind.data.frame(!!!estimators)
+      names(estimates)[names(estimates) == "N"] <- "N_DIM"
       estimates$estimator_label <- !!estimator_labels
       estimates$estimand_label <- rownames(estimates)
       estimates$estimate <- estimates$coefficients

--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -109,6 +109,18 @@ for(designer in designers){
                                                                   "max", "inspector_min", "inspector_step")), 0)
       }
     )
+    
+    test_that(
+      # Testing that `diagnose_design(expand_design())` works when calling every 
+      # possible design parameter by checking if estimator column names overlap with
+      # designer terms
+      desc = paste0("`expand_design()` works with ", designer, " (DDWizard requirement)"),
+      code = {
+        params <- designer_attr$definitions$names
+        estimator <- draw_estimates(the_designer())
+        expect_length(intersect(params, names(estimator)), 0)
+      }
+    )
   }
 }
 

--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -114,7 +114,7 @@ for(designer in designers){
       # Testing that `diagnose_design(expand_design())` works when calling every 
       # possible design parameter by checking if estimator column names overlap with
       # designer terms
-      desc = paste0("`expand_design()` works with ", designer, " (DDWizard requirement)"),
+      desc = paste0("No column names in estimator data.frame conflict with parameters in ", designer),
       code = {
         params <- designer_attr$definitions$names
         estimator <- draw_estimates(the_designer())


### PR DESCRIPTION
- Changes multi-arm estimator column label from "N" to "N_DIM."
- Includes test to avoid conflicting label columns in expanded design diagnosis. More specifically, it checks that no column names in estimate data frame are the same as designer arguments (this would generate errors in DDWizard when it calls `diagnose_design()` on an object returned by `expand_design()`).