### PR TITLE
Fix many fixed

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -173,12 +173,12 @@ construct_design_code <- function(designer, args, args_to_fix = NULL,
     list_fixed <- setNames(mapply(function(arg_to_fix) args[[arg_to_fix]], args_to_fix), args_to_fix)
     if(!is.list(list_fixed)) list_fixed <- as.list(list_fixed)
     # create string of list of arguments to substitute
-    list_fixed_str <- str_within(deparse(expr(!!list_fixed), width.cutoff = 60L))
+    list_fixed_str <- str_within(deparse(expr(!!list_fixed)))
     # bundle code lines related to same assignment function together
     design_exprs <- mapply(function(lines) paste0(code[lines], collapse = " "), expr_i)
 
     # evaluate a parsed expression where we substitute fixed arguments for their values
-    fixed_code_lines <- lapply(design_exprs, code_fixer, list_fixed_str = list_fixed_str, eval_envir = ee)
+    fixed_code_lines <- lapply(design_exprs, code_fixer, list_fixed_str = paste0(list_fixed_str, collapse = ""), eval_envir = ee)
     
     code_fixed <- code
     for(i in seq_along(expr_i)){

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -160,23 +160,22 @@ construct_design_code <- function(designer, args, args_to_fix = NULL,
     invisible(assign(i, eval(args[[i]], envir=ee), ee))
   }
   args_eval <- mget(arg_names, envir = ee)
-
-  # for each of the expressions separated by new
-  # line turn from string to expression
-  # substitute the arguments for their (evaluated)
-  # values if they are set in args_to_fix
-  expr_i <- group_code_lines(code)
   
   #if any arguments are set to fixed
   if(!is.null(args_to_fix)){
+    
+    # for each of the expressions separated by new line turn from string to 
+    # expression substitute the arguments for their (evaluated) values if they are 
+    # set in args_to_fix
+    expr_i <- group_code_lines(code)
     #list of fixed arguments
     list_fixed <- setNames(mapply(function(arg_to_fix) args[[arg_to_fix]], args_to_fix), args_to_fix)
     if(!is.list(list_fixed)) list_fixed <- as.list(list_fixed)
     # create string of list of arguments to substitute
     list_fixed_str <- str_within(deparse(expr(!!list_fixed)))
     # bundle code lines related to same assignment function together
-    design_exprs <- mapply(function(lines) paste0(code[lines], collapse = " "), expr_i)
-
+    design_exprs <- mapply(function(lines) paste0(code[lines], collapse = "\n"), expr_i)
+    
     # evaluate a parsed expression where we substitute fixed arguments for their values
     fixed_code_lines <- lapply(design_exprs, code_fixer, list_fixed_str = paste0(list_fixed_str, collapse = ""), eval_envir = ee)
     
@@ -186,6 +185,11 @@ construct_design_code <- function(designer, args, args_to_fix = NULL,
     }
     
     code <- unique(code_fixed)
+    # if(length(with_comments)>1L){
+    #   for(i in 1:nrow(paste_comments)){
+    #     code <- gsub(paste_comments[i,1], paste_comments[i,2], code)
+    #   }
+    # }
   }
   }
 

--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -39,8 +39,8 @@ for(designer in designers){
   testthat::test_that(
     desc = paste0(designer, " works when all arguments are fixed in `args_to_fix`"),
     code = {
-      expect_error(eval(expr(paste0("", designer, 
-                                    "(args_to_fix = names(formals(", designer, ")))"))), NA)
+      expect_error(eval(parse_expr(paste0("", designer, 
+                                          "(args_to_fix = names(formals(", designer, ")))"))), NA)
     })
   
   testthat::test_that(

--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -2,12 +2,12 @@
 context(desc = "Testing that designers in the library work as they should")
 
 functions <- ls("package:DesignLibrary")
-designers <- functions[grepl("_designer\\b",functions)]
-designers <- designers[!grepl("simple",designers)]
+designer_names <- functions[grepl("_designer\\b",functions)]
+designer_names <- designer_names[!grepl("simple",designer_names)]
 
-for(designer in designers){
+for(designer_name in designer_names){
   
-  the_designer <- get(x = designer)
+  the_designer <- get(x = designer_name)
   has_shiny <- !is.null(attributes(the_designer)$shiny_arguments)
   has_definition <- !is.null(attributes(the_designer)$definitions)
   
@@ -17,49 +17,49 @@ for(designer in designers){
   design_attr <- attributes(one_design)
   
   testthat::test_that(
-    desc = paste0("designs returned by ", designer," should have a code attribute"),
+    desc = paste0("designs returned by ", designer_name," should have a code attribute"),
     code = {
       expect_true("code" %in% names(design_attr)) 
     }
   )
   
   testthat::test_that(
-    desc = paste0(designer," returns a DD-type design."),
+    desc = paste0(designer_name," returns a DD-type design."),
     code = {
       expect_true("design" %in% class(one_design))
     })
   
   
   testthat::test_that(
-    desc = paste0(designer,"'s default design runs."),
+    desc = paste0(designer_name,"'s default design runs."),
     code = {
       expect_is( DeclareDesign::diagnose_design(one_design, sims = 10, bootstrap_sims = FALSE)$diagnosands_df, "data.frame" )
     })
   
   testthat::test_that(
-    desc = paste0(designer, " works when all arguments are fixed in `args_to_fix`"),
+    desc = paste0(designer_name, " works when all arguments are fixed in `args_to_fix`"),
     code = {
-      expect_error(eval(parse_expr(paste0("", designer, 
-                                          "(args_to_fix = names(formals(", designer, ")))"))), NA)
+      expect_error(eval(parse_expr(paste0("", designer_name, 
+                                          "(args_to_fix = names(formals(", designer_name, ")))"))), NA)
     })
   
   testthat::test_that(
-    desc = paste0(designer, " should return designs that have code as a character string in attributes"),
+    desc = paste0(designer_name, " should return designs that have code as a character string in attributes"),
     code = {
       expect_true(class(design_attr$code) == "character")
     })
   
   testthat::test_that(
-    desc = paste0(designer, "'s default design code runs without errors"),
+    desc = paste0(designer_name, "'s default design code runs without errors"),
     code = {
       expect_error(eval(parse(text = get_design_code(one_design))), NA)
     })
   
   testthat::test_that(
-    desc = paste0("Code inside ",designer, " runs and creates an appropriately named design object."),
+    desc = paste0("Code inside ",designer_name, " runs and creates an appropriately named design object."),
     code = {
       eval(parse(text = design_attr$code))
-      expect_true(exists(x = gsub("_designer\\b","_design",designer)))
+      expect_true(exists(x = gsub("_designer\\b","_design",designer_name)))
     })
   
   
@@ -69,7 +69,7 @@ for(designer in designers){
     shiny_tips <- designer_attr$definitions$names
     
     testthat::test_that(
-      desc = paste0("Any shiny_arguments in the attributes of ",designer," should all be in the its formals."),
+      desc = paste0("Any shiny_arguments in the attributes of ",designer_name," should all be in the its formals."),
       code = {
         expect_true(
           all(names(shiny_arguments) %in% names(designer_args))
@@ -77,7 +77,7 @@ for(designer in designers){
       }
     )
     testthat::test_that(
-      desc = paste0("All shiny_arguments in the attributes of ",designer," have a tip."),
+      desc = paste0("All shiny_arguments in the attributes of ",designer_name," have a tip."),
       code = {
         expect_true(all(names(shiny_arguments) %in% shiny_tips))
       }
@@ -86,7 +86,7 @@ for(designer in designers){
   
   if(has_definition){
     test_that(
-      desc = paste0("Definitions attribute of ", designer," has the same row number as its formals."),
+      desc = paste0("Definitions attribute of ", designer_name," has the same row number as its formals."),
       code = {
         definitions <- designer_attr$definitions
         expect_equal(nrow(definitions), length(designer_args)
@@ -95,14 +95,14 @@ for(designer in designers){
     )
     
     test_that(
-      desc = paste0("All 'names' in definitions attribute of ", designer," are contained in its formals."),
+      desc = paste0("All 'names' in definitions attribute of ", designer_name," are contained in its formals."),
       code = {
         definitions <- designer_attr$definitions
         expect_true(all(definitions$names %in% names(designer_args)))
       }
     )
     test_that(
-      desc = paste0("All 'class' values in  definitions attribute of ", designer," exist."),
+      desc = paste0("All 'class' values in  definitions attribute of ", designer_name," exist."),
       code = {
         classes <- designer_attr$definitions[["class"]]
         expect_true(all(classes %in% c("character", "numeric", "integer", "logical")))
@@ -110,7 +110,7 @@ for(designer in designers){
     )
     
     test_that(
-      desc = paste0("Definitions attribute of ", designer, " contains all columns."),
+      desc = paste0("Definitions attribute of ", designer_name, " contains all columns."),
       code= {
         expect_length(setdiff(names(designer_attr$definitions), c("names", "tips", "class", "vector", "min", 
                                                                   "max", "inspector_min", "inspector_step")), 0)
@@ -121,7 +121,7 @@ for(designer in designers){
       # Testing that `diagnose_design(expand_design())` works when calling every 
       # possible design parameter by checking if estimator column names overlap with
       # designer terms
-      desc = paste0("No column names in estimator data.frame conflict with parameters in ", designer),
+      desc = paste0("No column names in estimator data.frame conflict with parameters in ", designer_name),
       code = {
         params <- designer_attr$definitions$names
         estimator <- draw_estimates(the_designer())

--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -37,6 +37,13 @@ for(designer in designers){
     })
   
   testthat::test_that(
+    desc = paste0(designer, " works when all arguments are fixed in `args_to_fix`"),
+    code = {
+      expect_error(eval(expr(paste0("", designer, 
+                                    "(args_to_fix = names(formals(", designer, ")))"))), NA)
+    })
+  
+  testthat::test_that(
     desc = paste0(designer, " should return designs that have code as a character string in attributes"),
     code = {
       expect_true(class(design_attr$code) == "character")
@@ -286,16 +293,6 @@ test_that(desc = "binary_iv_designer errors when it should",
             expect_error(binary_iv_designer(b = -20))
             expect_error(binary_iv_designer(d = -20))
           })
-
-
-# Test `args_to_fix` argument works ---------------------------------------------
-
-test_that(desc = "args_to_fix argument works",
-          code = {
-            expect_error(factorial_designer(args_to_fix = names(formals(factorial_designer))), NA)
-            expect_error(multi_arm_designer(args_to_fix = names(formals(multi_arm_designer))), NA)
-          })
-
 
 test_that(desc = "block_cluster designer handles reports ICC with verbose = TRUE",
           code = {


### PR DESCRIPTION
Issue #246: Designers were retuning error when all arguments were fixed for some designers. For example:
```
pretest_posttest_designer(args_to_fix = names(formals(pretest_posttest_designer)))
```
> Error in parse(text = x) : <text>:1:131: unexpected symbol
1: substitute({report     <- declare_assignment(prob = 1 - attrition_rate,                                  assignment_variable = R) reveal_t2

PR
- Fixes issue above
- Adds tests for whether all designers work when all arguments are fixed

Note

Current use of substitute does not preserve comments in line. It only preserves comment lines that are separated from previous and subsequent code lines by a new line. For example, all of the below are preserved:

```
# D: Data Strategy 1
    select_case <- declare_sampling(
      strata = paste(X, Y),
      strata_n = c("X0Y0" = 0, "X0Y1" = 0, "X1Y0" = 0, "X1Y1" = 1))
    # I: Inquiry
    estimand <-
      declare_estimand(did_X_cause_Y = causal_process == 'X_causes_Y')
    # D: Data Strategy 2
    # Calculate bivariate probabilities given correlation
    
    joint_prob <- function(p1, p2, rho) {
...
```
But not the following:
```
population <- declare_population(
      N = N,
      X = rbinom(N, 1, prob_X) == 1,
      Y = (X & causal_process == "X_causes_Y") | # 1. X causes Y
        (!X & causal_process == "X_causes_not_Y") | # 2. Not X causes Y
        (causal_process == "Y_regardless") # 3. Y happens irrespective of X
    )
```
