### PR TITLE
Warning when factorial arguments conflict

### DIFF
--- a/R/factorial_designer.R
+++ b/R/factorial_designer.R
@@ -99,6 +99,8 @@ factorial_designer <- function(
   if(k < 2 || !is_integerish(k)) stop("`k' should be a positive integer > 1.")
   if(any(outcome_sds<0)) stop("`outcome_sds' should be nonnegative.")
   if(any(assignment_probs <= 0)) stop("`assignment_probs' should have positive values only.")
+  if(!is.null(sd) && !is.null(outcome_sds) && outcome_sds != rep(sd, k^2))
+    warning("Both `sd` and `outcome_sd` are specified and have different values. Taking value of `outcome_sds`.")
   
   # pre-objects -------------------------------------------------------------
   

--- a/tests/testthat/test_designers.R
+++ b/tests/testthat/test_designers.R
@@ -249,7 +249,7 @@ test_that(desc = "two_arm_covariate_designer errors when it should",
             expect_error(two_arm_covariate_designer(rho_WZ = 10))
           })
 
-test_that(desc = "factorial_designer errors when it should",
+test_that(desc = "factorial_designer errors or warns when it should",
           code = {
             expect_error(factorial_designer(outcome_name = c("Y ")))
             expect_error(factorial_designer(outcome_means = 1, k = 2))
@@ -260,6 +260,7 @@ test_that(desc = "factorial_designer errors when it should",
             expect_error(factorial_designer(k = .5))
             expect_error(factorial_designer(outcome_sds = c(-1,-1,-1,-1), k = 2))
             expect_error(factorial_designer(assignment_probs = c(-.5,.5), k = 2))
+            expect_warning(factorial_designer(k = 2, sd = 1, outcome_sds = rep(.5, 4)))
           })
 
 test_that(desc = "process_tracing_designer errors when it should",


### PR DESCRIPTION
Return warning for which value takes precedence when user inputs both `sd` and `outcome_sds` and they do not match.